### PR TITLE
Add support for atmega32u4 chip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,10 +54,10 @@ justflash: $(HEXFILE)
 	./scripts/wait_then_flash.sh $(CPU) $(HEXFILE)
 
 chip_erase:
-	dfu-programmer atmega32u2 erase
+	dfu-programmer $(CPU) erase
 
 reset:
-	dfu-programmer atmega32u2 reset
+	dfu-programmer $(CPU) reset
 
 restart:
 	- ./scripts/enter_bootloader.sh

--- a/usb.c
+++ b/usb.c
@@ -785,7 +785,7 @@ void usb_doTasks(void)
 	}
 }
 
-#if defined(__AVR_ATmega32U2__)
+#if defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega32U4__)
 
 /* Atmega32u2 datasheet 8.11.6, PLLCSR.
  * But register summary says PLLP0... */
@@ -851,8 +851,10 @@ void usb_init(const struct usb_parameters *params)
 	USBCON |= (1<<FRZCLK); // initial value
 #ifdef UHWCON
 	UHWCON |= (1<<UVREGE); // Enable USB pad regulator
+	#if defined(UIDE) && defined(UIMOD)
 	UHWCON &= ~(1<<UIDE);
 	UHWCON |= (1<UIMOD);
+	#endif
 #endif
 
 #ifdef UPOE


### PR DESCRIPTION
This PR adds support for the atmega32u4 chips, including this compatible with the Arduino Leonardo. I have personally tested this with a regular GC gamepad on a cheap Chinese knockoff Arduino Pro Micro from AliExpress.

I have not tested the flashing mechanism using `dfu-programmer`, because I personally prefer `avrdude`. I used this script to flash the device:

```shell
#!/bin/sh

readonly HEX="gcn64usb.hex"

sudo avrdude -v -p atmega32u4 -P /dev/ttyACM0 -c avr109 -b 115200 -U "flash:w:${HEX}:i"
```

To be enable the build for the atmega32u4, the user will have to update the Makefile:

```diff
diff --git a/Makefile b/Makefile
index 0c14469..944e2f2 100644
--- a/Makefile
+++ b/Makefile
@@ -9 +9 @@ OBJDIR=objs-$(PROGNAME)
-CPU=atmega32u2
+CPU=atmega32u4
```