### PR TITLE
Fix & Improve ATmega32u4 support

### DIFF
--- a/Makefile.32u4
+++ b/Makefile.32u4
@@ -1,0 +1,64 @@
+CC=avr-gcc
+AS=$(CC)
+LD=$(CC)
+
+include Makefile.inc
+
+PROGNAME=gcn64usb
+OBJDIR=objs-$(PROGNAME)
+CPU=atmega32u4
+CFLAGS=-Wall -mmcu=$(CPU) -DF_CPU=16000000L -Os -DUART1_STDOUT -DVERSIONSTR=$(VERSIONSTR) -DVERSIONSTR_SHORT=$(VERSIONSTR_SHORT) -DVERSIONBCD=$(VERSIONBCD) -std=gnu99
+LDFLAGS=-mmcu=$(CPU) -Wl,-Map=$(PROGNAME).map
+HEXFILE=$(PROGNAME).hex
+
+all: $(HEXFILE)
+
+clean:
+	rm -f $(PROGNAME).elf $(PROGNAME).hex $(PROGNAME).map $(OBJS)
+
+gcn64txrx0.o: gcn64txrx.S
+	$(CC) $(CFLAGS) -c $< -o $@ -DSUFFIX=0 -DGCN64_DATA_BIT=0
+
+gcn64txrx1.o: gcn64txrx.S
+	$(CC) $(CFLAGS) -c $< -o $@ -DSUFFIX=1 -DGCN64_DATA_BIT=2
+
+gcn64txrx2.o: gcn64txrx.S
+	$(CC) $(CFLAGS) -c $< -o $@ -DSUFFIX=2 -DGCN64_DATA_BIT=1
+
+gcn64txrx3.o: gcn64txrx.S
+	$(CC) $(CFLAGS) -c $< -o $@ -DSUFFIX=3 -DGCN64_DATA_BIT=3
+
+%.o: %.S
+	$(CC) $(CFLAGS) -c $< -o $@
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@
+
+%.o: %.c %.h
+	$(CC) $(CFLAGS) -c $< -o $@
+
+$(PROGNAME).elf: $(OBJS)
+	$(LD) $(OBJS) $(LDFLAGS) -o $(PROGNAME).elf
+
+$(PROGNAME).hex: $(PROGNAME).elf
+	avr-objcopy -j .data -j .text -O ihex $(PROGNAME).elf $(PROGNAME).hex
+	avr-size $(PROGNAME).elf -C --mcu=$(CPU)
+
+fuse:
+
+flash: $(HEXFILE)
+	- ./scripts/enter_bootloader.sh
+	./scripts/wait_then_flash.sh $(CPU) $(HEXFILE)
+
+justflash: $(HEXFILE)
+	./scripts/wait_then_flash.sh $(CPU) $(HEXFILE)
+
+chip_erase:
+	dfu-programmer $(CPU) erase
+
+reset:
+	dfu-programmer $(CPU) reset
+
+restart:
+	- ./scripts/enter_bootloader.sh
+	./scripts/start.sh $(CPU)

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The project is released under the General Public License version 3.
 
 You will need a working avr-gcc toolchain with avr-libc and standard utilities such as make. Just
 type 'make' and it should build just fine. Under Linux at least.
+If you are compiling for a custom board or Arduino running on an ATmega32u4, then run 'make -f Makefile.32u4' instead.
 
 ## Programming the firmware
 

--- a/bootloader.c
+++ b/bootloader.c
@@ -26,7 +26,7 @@ void enterBootLoader(void)
 	usb_shutdown();
 	_delay_ms(10);
 
-#if defined(__AVR_ATmega32U2__)
+#if defined(__AVR_ATmega32U2__) || defined(__AVR_ATmega32U4__)
 	// ATmega32u2   : 0x3800
 	asm volatile(
 		"cli			\n"

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,5 @@
 - Future ideas / TODO
   - Add very basic N64 mouse support (detect and treat it like a controller)
-  - Add support for Atmega32u4 MCU
 
 - March 5, 2021 : Version 3.6.1
   - Alter timing so the brawler64 wireless gamepad will work. Those will now


### PR DESCRIPTION
I've made a couple of improvements to support for the Arduino Leonardo and other boards based on an ATmega32u4 chip:

ATmega32u4 support was added in commit 7e90c06cf933db95a7fe7b5991343d010995a633 but broken again in commit ee3adafd2640b00cfe0f40e888b12bee4e19f11f, however this is easily rectified by adding a second define statement to account for both chips.

I have added a new 32u4 specific makefile and added instructions on how to use it to the readme, as it was very unclear how to compile for a 32u4 before.

With these changes 32u4 support should be fully complete, therefore I have removed it from the TODO section in the changelog.

Let me know if you find any issues, and I can get them fixed.